### PR TITLE
Fix 1 Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,8 @@
     "ip-address": "^10.1.1",
     "shell-quote": "^1.8.4",
     "@babel/core": "7.29.6",
-    "**/@babel/core": "7.29.6"
+    "**/@babel/core": "7.29.6",
+    "brace-expansion": "5.0.7",
+    "**/brace-expansion": "5.0.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2691,10 +2691,10 @@ boxen@^8.0.1:
     widest-line "^5.0.0"
     wrap-ansi "^9.0.0"
 
-brace-expansion@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.3.tgz#6a9c6c268f85b53959ec527aeafe0f7300258eef"
-  integrity sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==
+brace-expansion@5.0.7, brace-expansion@^5.0.2:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
| Package | Ecosystem | Severity | From → To | Advisory (GHSA) | Alert # |
|---|---|---|---|---|---|
| brace-expansion | npm | high | 5.0.3 → 5.0.7 | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | #144 |

## Needs manual review

None — the fix was a minor/patch bump within the same major version, applied via `resolutions` in `package.json`.